### PR TITLE
map ceph-ansible 3.1 to jewel and luminous

### DIFF
--- a/run.py
+++ b/run.py
@@ -127,6 +127,8 @@ def get_cbs_target(version):
     version = re.sub('^v', '', version)
     if version.startswith('3.0.'):
         return 'storage7-ceph-jewel-el7'
+    if version.startswith('3.1.'):
+        return 'storage7-ceph-jewel-el7'
     return None
 
 
@@ -140,6 +142,8 @@ def get_needed_cbs_tags(version):
     version = re.sub('^v', '', version)
     releases = []
     if version.startswith('3.0.'):
+        releases = ['jewel', 'luminous']
+    if version.startswith('3.1.'):
         releases = ['jewel', 'luminous']
     return ['storage7-ceph-%s-candidate' % release for release in releases]
 


### PR DESCRIPTION
Build ceph-ansible 3.1 in the -jewel-el7 CBS target.

Cross-tag ceph-ansible 3.1 into -luminous.